### PR TITLE
Return viewer URL from validate_path on success

### DIFF
--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -119,7 +119,7 @@ export function createMcpServer(config: Config): Server {
       {
         name: "validate_path",
         description:
-          `Validates a markdown file at the given absolute filesystem path, checking for Mermaid diagram syntax errors. Configured directories: ${sourceListDescription()}`,
+          `Validates a markdown file at the given absolute filesystem path, checking for Mermaid diagram syntax errors. Returns the viewer URL on success. Configured directories: ${sourceListDescription()}. Viewer: ${viewerUrl()}`,
         inputSchema: {
           type: "object" as const,
           properties: {
@@ -211,8 +211,12 @@ export function createMcpServer(config: Config): Server {
 
         const errors = await validateMermaidBlocks(content);
         if (errors.length === 0) {
+          const viewName = match.relative.endsWith(".md")
+            ? match.relative.slice(0, -3)
+            : match.relative;
+          const url = `${viewerUrl()}/${match.source.name}/${viewName}`;
           return {
-            content: [{ type: "text", text: "Valid — no Mermaid syntax errors found." }],
+            content: [{ type: "text", text: `Valid — no Mermaid syntax errors found.\n\nViewer URL: ${url}` }],
           };
         }
 


### PR DESCRIPTION
## Summary

- `validate_path` now includes the viewer URL in its response when validation succeeds, reducing the happy path from 2 tool calls to 1
- Tool description updated to document the new behavior
- `get_url_for_path` remains unchanged as a standalone tool for linking without re-validating

Closes #3

## Test plan

- [ ] Call `validate_path` on a valid markdown file — response should include both the success message and the viewer URL
- [ ] Call `validate_path` on a file with Mermaid syntax errors — response should contain only errors, no URL
- [ ] Call `validate_path` on a nonexistent file — error response unchanged
- [ ] Call `get_url_for_path` — behavior unchanged
- [ ] Verify the tool description in `list_tools` mentions the viewer URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)