### PR TITLE
Remove tailscaleUrl config option, always auto-detect from Tailscale

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -28,7 +28,6 @@ interface RawConfig {
   port?: number;
   host?: string;
   tailscale?: boolean;
-  tailscaleUrl?: string;
 }
 
 function resolveTilde(filePath: string) {
@@ -106,6 +105,5 @@ export async function loadConfig(): Promise<Config> {
     port: args.port ?? raw?.port ?? DEFAULT_PORT,
     host: args.host ?? raw?.host ?? DEFAULT_HOST,
     tailscale: args.tailscale ?? raw?.tailscale ?? DEFAULT_TAILSCALE,
-    tailscaleUrl: raw?.tailscaleUrl,
   };
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -65,11 +65,11 @@ async function main() {
     console.log(`  ${source.name} → ${source.directory}`);
   }
 
-  if (config.tailscale && !config.tailscaleUrl) {
+  if (config.tailscale) {
     config.tailscaleUrl = await setupTailscale(config.port);
-  }
-  if (config.tailscaleUrl) {
-    console.log(`Tailscale: ${config.tailscaleUrl}`);
+    if (config.tailscaleUrl) {
+      console.log(`Tailscale: ${config.tailscaleUrl}`);
+    }
   }
 }
 
@@ -89,9 +89,7 @@ async function setupTailscale(port: number): Promise<string | undefined> {
     const status = JSON.parse(stdout) as { Self?: { DNSName?: string } };
     const dnsName = status.Self?.DNSName?.replace(/\.$/, "");
     if (dnsName) {
-      const url = `https://${dnsName}/`;
-      console.log(`Tailscale: ${url}`);
-      return url;
+      return `https://${dnsName}/`;
     }
   } catch (error: unknown) {
     if (isCommandNotFound(error)) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -97,7 +97,7 @@ async function setupTailscale(port: number): Promise<string | undefined> {
         "Warning: tailscale command not found. Continuing without Tailscale.",
       );
     } else {
-      console.warn("Warning: Tailscale setup failed:", (error as Error).message);
+      console.warn("Warning: Tailscale setup failed:", String(error));
     }
   }
   return undefined;

--- a/src/types.ts
+++ b/src/types.ts
@@ -15,6 +15,6 @@ export interface Config {
   port: number;
   host: string;
   tailscale: boolean;
-  /** Explicit Tailscale URL override. Set by config file or resolved at runtime. */
+  /** Resolved at runtime from `tailscale status --json` when tailscale is enabled. */
   tailscaleUrl?: string;
 }


### PR DESCRIPTION
## Summary

- Removed `tailscaleUrl` from the config file schema — it was a footgun that went stale when the machine's Tailscale hostname changed
- The server now always discovers the hostname dynamically via `tailscale status --json` when `tailscale: true`
- Cleaned up duplicate `console.log` in `setupTailscale()`

Closes #5

## Test plan

- [ ] Run with `tailscale: true` in config and verify the correct hostname is logged
- [ ] Run without Tailscale and verify no errors
- [ ] Confirm MCP `get_url_for_path` returns the auto-detected Tailscale URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)