### PR TITLE
Add post-merge hook to rebuild and restart on pull

### DIFF
--- a/.githooks/post-merge
+++ b/.githooks/post-merge
@@ -1,0 +1,16 @@
+#!/bin/bash
+# Rebuild and restart agent-md-server after pulling changes on main.
+# Only runs when on the main branch.
+
+BRANCH=$(git rev-parse --abbrev-ref HEAD)
+if [ "$BRANCH" != "main" ]; then
+  exit 0
+fi
+
+echo "post-merge: rebuilding agent-md-server..."
+npm run build 2>&1
+
+echo "post-merge: restarting launchd service..."
+launchctl kickstart -k "gui/$(id -u)/io.semvia.agent-md-server" 2>&1
+
+echo "post-merge: done."

--- a/README.md
+++ b/README.md
@@ -16,8 +16,7 @@ A thin server for helping you and your agent of choice communicate with rendered
 ## Quick start
 
 ```bash
-pnpm install
-pnpm build
+bash scripts/setup.sh   # install, build, configure git hooks
 node dist/main.js
 ```
 
@@ -135,6 +134,16 @@ pnpm build  # Build for production
 ```
 
 Requires Node.js >= 22.
+
+### Git hooks
+
+The repo uses checked-in git hooks in `.githooks/`. The setup script configures this automatically, but you can also run it manually:
+
+```bash
+git config core.hooksPath .githooks
+```
+
+**`post-merge`** — When you pull changes on the `main` branch, automatically rebuilds and restarts the launchd service (`io.semvia.agent-md-server`).
 
 ## License
 

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+# One-time setup after cloning the repository.
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+
+echo "Installing dependencies..."
+npm install
+
+echo "Building..."
+npm run build
+
+echo "Configuring git hooks..."
+git config core.hooksPath .githooks
+
+echo "Setup complete."


### PR DESCRIPTION
## Summary
- Add `.githooks/post-merge` hook that rebuilds and restarts the launchd service when pulling changes on `main`
- Add `scripts/setup.sh` for one-time clone setup (install, build, configure hooks path)
- Update README with setup script and git hooks documentation

## Test plan
- [ ] Clone fresh, run `bash scripts/setup.sh`, verify `git config core.hooksPath` returns `.githooks`
- [ ] On `main`, run `git pull` after a merge — verify build runs and service restarts

🤖 Generated with [Claude Code](https://claude.com/claude-code)