### PR TITLE
feat: support nested source paths (/claude/plans/) and serve ~/.claude/plans by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ The config file lives at `~/.config/agent-md-server/config.json`.
 {
   "sources": {
     "plans": "~/plans",
+    "claude/plans": "~/.claude/plans",
     "temp": "/tmp/agent-md-server"
   },
   "port": 3333,
@@ -47,9 +48,9 @@ Defaults are applied when the config file is missing or a field is omitted.
 ### Sources
 
 Sources are name-to-path mappings.
-Each source name becomes a URL prefix (`/plans/`, `/temp/`, etc.).
+Each source name becomes a URL prefix (`/plans/`, `/claude/plans/`, `/temp/`, etc.).
 
-- Names must match `[a-z0-9-]` (lowercase alphanumeric and hyphens).
+- Names are one or more `[a-z0-9-]` segments joined by `/`. Each segment becomes a URL path segment — e.g. `claude/plans` is served at `/claude/plans/`.
 - Paths support `~` expansion to the home directory.
 - Directories are created automatically if they do not exist.
 
@@ -58,6 +59,7 @@ Default sources when no config file is present:
 | Name | Path |
 |------|------|
 | `plans` | `~/plans` |
+| `claude/plans` | `~/.claude/plans` |
 | `temp` | `/tmp/agent-md-server` |
 
 ## CLI flags
@@ -121,6 +123,8 @@ If the `tailscale` command is not found, the server continues without it and pri
 /api/:source/foo.md       Raw markdown content
 /events/:source/foo.md    SSE stream (emits on file change)
 ```
+
+`:source` may itself be a multi-segment prefix (e.g. `claude/plans`), in which case the URLs include each segment — `/claude/plans/foo`, `/api/claude/plans/foo.md`, etc.
 
 The `/api/` endpoints return JSON (listings) or raw markdown (files).
 The `/events/` endpoint opens a persistent SSE connection that sends a `changed` event whenever the file is modified on disk.

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "node": ">=22"
   },
   "dependencies": {
-    "@fastify/static": "^9.0.0",
     "@modelcontextprotocol/sdk": "^1.28.0",
     "fastify": "^5.8.4",
     "playwright": "^1.58.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,9 +8,6 @@ importers:
 
   .:
     dependencies:
-      '@fastify/static':
-        specifier: ^9.0.0
-        version: 9.0.0
       '@modelcontextprotocol/sdk':
         specifier: ^1.28.0
         version: 1.28.0(zod@4.3.6)
@@ -192,9 +189,6 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@fastify/accept-negotiator@2.0.1':
-    resolution: {integrity: sha512-/c/TW2bO/v9JeEgoD/g1G5GxGeCF1Hafdf79WPmUlgYiBXummY0oX3VVq4yFkKKVBKDNlaDUYoab7g38RpPqCQ==}
-
   '@fastify/ajv-compiler@4.0.5':
     resolution: {integrity: sha512-KoWKW+MhvfTRWL4qrhUwAAZoaChluo0m0vbiJlGMt2GXvL4LVPQEjt8kSpHI3IBq5Rez8fg+XeH3cneztq+C7A==}
 
@@ -212,12 +206,6 @@ packages:
 
   '@fastify/proxy-addr@5.1.0':
     resolution: {integrity: sha512-INS+6gh91cLUjB+PVHfu1UqcB76Sqtpyp7bnL+FYojhjygvOPA9ctiD/JDKsyD9Xgu4hUhCSJBPig/w7duNajw==}
-
-  '@fastify/send@4.1.0':
-    resolution: {integrity: sha512-TMYeQLCBSy2TOFmV95hQWkiTYgC/SEx7vMdV+wnZVX4tt8VBLKzmH8vV9OzJehV0+XBfg+WxPMt5wp+JBUKsVw==}
-
-  '@fastify/static@9.0.0':
-    resolution: {integrity: sha512-r64H8Woe/vfilg5RTy7lwWlE8ZZcTrc3kebYFMEUBrMqlydhQyoiExQXdYAy2REVpST/G35+stAM8WYp1WGmMA==}
 
   '@hono/node-server@1.19.11':
     resolution: {integrity: sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g==}
@@ -237,10 +225,6 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
-
-  '@lukeed/ms@2.0.2':
-    resolution: {integrity: sha512-9I2Zn6+NJLfaGoz9jN3lpwDgAYvfGeNYdbAIjJOqzs4Tpc+VU3Jqq4IofSUBKajiDS8k9fZIg18/z13mpk1bsA==}
-    engines: {node: '>=8'}
 
   '@modelcontextprotocol/sdk@1.28.0':
     resolution: {integrity: sha512-gmloF+i+flI8ouQK7MWW4mOwuMh4RePBuPFAEPC6+pdqyWOUMDOixb6qZ69owLJpz6XmyllCouc4t8YWO+E2Nw==}
@@ -432,17 +416,9 @@ packages:
   avvio@9.2.0:
     resolution: {integrity: sha512-2t/sy01ArdHHE0vRH5Hsay+RtCZt3dLPji7W7/MMOCEgze5b7SNDC4j5H6FnVgPkI1MTNFGzHdHrVXDDl7QSSQ==}
 
-  balanced-match@4.0.4:
-    resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
-    engines: {node: 18 || 20 || >=22}
-
   body-parser@2.2.2:
     resolution: {integrity: sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==}
     engines: {node: '>=18'}
-
-  brace-expansion@5.0.5:
-    resolution: {integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==}
-    engines: {node: 18 || 20 || >=22}
 
   bundle-require@5.1.0:
     resolution: {integrity: sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA==}
@@ -594,9 +570,6 @@ packages:
   fast-uri@3.1.0:
     resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
 
-  fastify-plugin@5.1.0:
-    resolution: {integrity: sha512-FAIDA8eovSt5qcDgcBvDuX/v0Cjz0ohGhENZ/wpc3y+oZCY2afZ9Baqql3g/lC+OHRnciQol4ww7tuthOb9idw==}
-
   fastify@5.8.4:
     resolution: {integrity: sha512-sa42J1xylbBAYUWALSBoyXKPDUvM3OoNOibIefA+Oha57FryXKKCZarA1iDntOCWp3O35voZLuDg2mdODXtPzQ==}
 
@@ -654,10 +627,6 @@ packages:
 
   get-tsconfig@4.13.7:
     resolution: {integrity: sha512-7tN6rFgBlMgpBML5j8typ92BKFi2sFQvIdpAqLA2beia5avZDrMs0FLZiM5etShWq5irVyGcGMEA1jcDaK7A/Q==}
-
-  glob@13.0.6:
-    resolution: {integrity: sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==}
-    engines: {node: 18 || 20 || >=22}
 
   gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
@@ -734,10 +703,6 @@ packages:
     resolution: {integrity: sha512-IXO6OCs9yg8tMKzfPZ1YmheJbZCiEsnBdcB03l0OcfK9prKnJb96siuHCr5Fl37/yo9DnKU+TLpxzTUspw9shg==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
-  lru-cache@11.2.7:
-    resolution: {integrity: sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==}
-    engines: {node: 20 || >=22}
-
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
@@ -760,19 +725,6 @@ packages:
   mime-types@3.0.2:
     resolution: {integrity: sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==}
     engines: {node: '>=18'}
-
-  mime@3.0.0:
-    resolution: {integrity: sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==}
-    engines: {node: '>=10.0.0'}
-    hasBin: true
-
-  minimatch@10.2.4:
-    resolution: {integrity: sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==}
-    engines: {node: 18 || 20 || >=22}
-
-  minipass@7.1.3:
-    resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
-    engines: {node: '>=16 || 14 >=14.17'}
 
   mlly@1.8.2:
     resolution: {integrity: sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==}
@@ -813,10 +765,6 @@ packages:
   path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
-
-  path-scurry@2.0.2:
-    resolution: {integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==}
-    engines: {node: 18 || 20 || >=22}
 
   path-to-regexp@8.4.0:
     resolution: {integrity: sha512-PuseHIvAnz3bjrM2rGJtSgo1zjgxapTLZ7x2pjhzWwlp4SJQgK3f3iZIQwkpEnBaKz6seKBADpM4B4ySkuYypg==}
@@ -1197,8 +1145,6 @@ snapshots:
   '@esbuild/win32-x64@0.27.4':
     optional: true
 
-  '@fastify/accept-negotiator@2.0.1': {}
-
   '@fastify/ajv-compiler@4.0.5':
     dependencies:
       ajv: 8.18.0
@@ -1222,23 +1168,6 @@ snapshots:
       '@fastify/forwarded': 3.0.1
       ipaddr.js: 2.3.0
 
-  '@fastify/send@4.1.0':
-    dependencies:
-      '@lukeed/ms': 2.0.2
-      escape-html: 1.0.3
-      fast-decode-uri-component: 1.0.1
-      http-errors: 2.0.1
-      mime: 3.0.0
-
-  '@fastify/static@9.0.0':
-    dependencies:
-      '@fastify/accept-negotiator': 2.0.1
-      '@fastify/send': 4.1.0
-      content-disposition: 1.0.1
-      fastify-plugin: 5.1.0
-      fastq: 1.20.1
-      glob: 13.0.6
-
   '@hono/node-server@1.19.11(hono@4.12.9)':
     dependencies:
       hono: 4.12.9
@@ -1256,8 +1185,6 @@ snapshots:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
-
-  '@lukeed/ms@2.0.2': {}
 
   '@modelcontextprotocol/sdk@1.28.0(zod@4.3.6)':
     dependencies:
@@ -1393,8 +1320,6 @@ snapshots:
       '@fastify/error': 4.2.0
       fastq: 1.20.1
 
-  balanced-match@4.0.4: {}
-
   body-parser@2.2.2:
     dependencies:
       bytes: 3.1.2
@@ -1408,10 +1333,6 @@ snapshots:
       type-is: 2.0.1
     transitivePeerDependencies:
       - supports-color
-
-  brace-expansion@5.0.5:
-    dependencies:
-      balanced-match: 4.0.4
 
   bundle-require@5.1.0(esbuild@0.27.4):
     dependencies:
@@ -1585,8 +1506,6 @@ snapshots:
 
   fast-uri@3.1.0: {}
 
-  fastify-plugin@5.1.0: {}
-
   fastify@5.8.4:
     dependencies:
       '@fastify/ajv-compiler': 4.0.5
@@ -1670,12 +1589,6 @@ snapshots:
     dependencies:
       resolve-pkg-maps: 1.0.0
 
-  glob@13.0.6:
-    dependencies:
-      minimatch: 10.2.4
-      minipass: 7.1.3
-      path-scurry: 2.0.2
-
   gopd@1.2.0: {}
 
   has-symbols@1.1.0: {}
@@ -1734,8 +1647,6 @@ snapshots:
 
   load-tsconfig@0.2.5: {}
 
-  lru-cache@11.2.7: {}
-
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -1751,14 +1662,6 @@ snapshots:
   mime-types@3.0.2:
     dependencies:
       mime-db: 1.54.0
-
-  mime@3.0.0: {}
-
-  minimatch@10.2.4:
-    dependencies:
-      brace-expansion: 5.0.5
-
-  minipass@7.1.3: {}
 
   mlly@1.8.2:
     dependencies:
@@ -1794,11 +1697,6 @@ snapshots:
   parseurl@1.3.3: {}
 
   path-key@3.1.1: {}
-
-  path-scurry@2.0.2:
-    dependencies:
-      lru-cache: 11.2.7
-      minipass: 7.1.3
 
   path-to-regexp@8.4.0: {}
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -5,7 +5,7 @@ import node_util from "node:util";
 
 import type { Config, SourceConfig } from "./types.js";
 
-const VALID_SOURCE_NAME = /^[a-z0-9-]+$/;
+const VALID_SOURCE_NAME = /^[a-z0-9-]+(\/[a-z0-9-]+)*$/;
 
 const CONFIG_PATH = node_path.join(
   node_os.homedir(),
@@ -16,6 +16,7 @@ const CONFIG_PATH = node_path.join(
 
 const DEFAULT_SOURCES: Record<string, string> = {
   plans: "~/plans",
+  "claude/plans": "~/.claude/plans",
   temp: "/tmp/agent-md-server",
 };
 
@@ -40,7 +41,7 @@ function resolveTilde(filePath: string) {
 function validateSourceName(name: string) {
   if (!VALID_SOURCE_NAME.test(name)) {
     throw new Error(
-      `Invalid source name "${name}": must match /^[a-z0-9-]+$/`,
+      `Invalid source name "${name}": must be one or more [a-z0-9-] segments joined by "/" (e.g. "plans" or "claude/plans")`,
     );
   }
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -46,11 +46,36 @@ function validateSourceName(name: string) {
   }
 }
 
+function validateSourceSet(names: string[]) {
+  // Reject overlapping source names — one cannot be a path-prefix of another.
+  // e.g. "plans" + "plans/foo" would produce Fastify route collisions between
+  // "/plans/:file" (file under outer) and "/plans/foo/" (listing for inner).
+  for (let i = 0; i < names.length; i++) {
+    for (let j = i + 1; j < names.length; j++) {
+      const [a, b] = [names[i], names[j]];
+      if (
+        a === b ||
+        a.startsWith(b + "/") ||
+        b.startsWith(a + "/")
+      ) {
+        throw new Error(
+          `Overlapping source names "${a}" and "${b}": one cannot be a path-prefix of the other`,
+        );
+      }
+    }
+  }
+}
+
 function transformSources(sources: Record<string, string>): SourceConfig[] {
-  return Object.entries(sources).map(([name, directory]) => {
+  const entries = Object.entries(sources);
+  for (const [name] of entries) {
     validateSourceName(name);
-    return { name, directory: resolveTilde(directory) };
-  });
+  }
+  validateSourceSet(entries.map(([name]) => name));
+  return entries.map(([name, directory]) => ({
+    name,
+    directory: resolveTilde(directory),
+  }));
 }
 
 async function readConfigFile(): Promise<RawConfig | undefined> {
@@ -99,6 +124,11 @@ export async function loadConfig(): Promise<Config> {
   const args = parseArgs();
 
   const sources = transformSources(raw?.sources ?? DEFAULT_SOURCES);
+  if (sources.length === 0) {
+    console.warn(
+      "No sources configured; only the root index will be served.",
+    );
+  }
   await ensureDirectories(sources);
 
   return {

--- a/src/routes/file.ts
+++ b/src/routes/file.ts
@@ -7,36 +7,28 @@ export function registerFileRoutes(
   app: FastifyInstance,
   sources: SourceConfig[],
 ): void {
-  app.get("/api/:source/:file", async (request, reply) => {
-    const { source: sourceName, file: filename } = request.params as {
-      source: string;
-      file: string;
-    };
-    const source = sources.find((s) => s.name === sourceName);
+  for (const source of sources) {
+    app.get(`/api/${source.name}/:file`, async (request, reply) => {
+      const { file: filename } = request.params as { file: string };
 
-    if (!source) {
-      return reply
-        .status(404)
-        .send({ error: `Source "${sourceName}" not found` });
-    }
-
-    try {
-      const content = await readMarkdown(source.directory, filename);
-      return reply
-        .header("Content-Type", "text/markdown; charset=utf-8")
-        .send(content);
-    } catch (error: unknown) {
-      if (error instanceof Error) {
-        if ("code" in error && error.code === "ENOENT") {
-          return reply
-            .status(404)
-            .send({ error: `File "${filename}" not found` });
+      try {
+        const content = await readMarkdown(source.directory, filename);
+        return reply
+          .header("Content-Type", "text/markdown; charset=utf-8")
+          .send(content);
+      } catch (error: unknown) {
+        if (error instanceof Error) {
+          if ("code" in error && error.code === "ENOENT") {
+            return reply
+              .status(404)
+              .send({ error: `File "${filename}" not found` });
+          }
+          if (error.message.includes("Path traversal")) {
+            return reply.status(403).send({ error: "Forbidden" });
+          }
         }
-        if (error.message.includes("Path traversal")) {
-          return reply.status(403).send({ error: "Forbidden" });
-        }
+        return reply.status(500).send({ error: "Internal server error" });
       }
-      return reply.status(500).send({ error: "Internal server error" });
-    }
-  });
+    });
+  }
 }

--- a/src/routes/listing.ts
+++ b/src/routes/listing.ts
@@ -7,22 +7,15 @@ export function registerListingRoutes(
   app: FastifyInstance,
   sources: SourceConfig[],
 ): void {
-  app.get("/api/:source/", async (request, reply) => {
-    const { source: sourceName } = request.params as { source: string };
-    const source = sources.find((s) => s.name === sourceName);
+  for (const source of sources) {
+    app.get(`/api/${source.name}/`, async (_request, reply) => {
+      const files = await listFiles(source.directory);
+      const mapped = files.map((entry) => ({
+        ...entry,
+        path: `/${source.name}/${entry.name}`,
+      }));
 
-    if (!source) {
-      return reply
-        .status(404)
-        .send({ error: `Source "${sourceName}" not found` });
-    }
-
-    const files = await listFiles(source.directory);
-    const mapped = files.map((entry) => ({
-      ...entry,
-      path: `/${source.name}/${entry.name}`,
-    }));
-
-    return reply.send(mapped);
-  });
+      return reply.send(mapped);
+    });
+  }
 }

--- a/src/routes/watch.ts
+++ b/src/routes/watch.ts
@@ -7,41 +7,33 @@ export function registerWatchRoutes(
   app: FastifyInstance,
   sources: SourceConfig[],
 ): void {
-  app.get("/events/:source/:file", async (request, reply) => {
-    const { source: sourceName, file: filename } = request.params as {
-      source: string;
-      file: string;
-    };
-    const source = sources.find((s) => s.name === sourceName);
+  for (const source of sources) {
+    app.get(`/events/${source.name}/:file`, async (request, reply) => {
+      const { file: filename } = request.params as { file: string };
 
-    if (!source) {
-      return reply
-        .status(404)
-        .send({ error: `Source "${sourceName}" not found` });
-    }
+      // Validate the file exists before setting up the watcher
+      try {
+        await readMarkdown(source.directory, filename);
+      } catch {
+        return reply
+          .status(404)
+          .send({ error: `File "${filename}" not found` });
+      }
 
-    // Validate the file exists before setting up the watcher
-    try {
-      await readMarkdown(source.directory, filename);
-    } catch {
-      return reply
-        .status(404)
-        .send({ error: `File "${filename}" not found` });
-    }
+      reply.raw.writeHead(200, {
+        "Content-Type": "text/event-stream",
+        "Cache-Control": "no-cache",
+        Connection: "keep-alive",
+      });
+      reply.hijack();
 
-    reply.raw.writeHead(200, {
-      "Content-Type": "text/event-stream",
-      "Cache-Control": "no-cache",
-      Connection: "keep-alive",
+      const cleanup = watchFile(source.directory, filename, () => {
+        reply.raw.write("data: changed\n\n");
+      });
+
+      request.raw.on("close", () => {
+        cleanup();
+      });
     });
-    reply.hijack();
-
-    const cleanup = watchFile(source.directory, filename, () => {
-      reply.raw.write("data: changed\n\n");
-    });
-
-    request.raw.on("close", () => {
-      cleanup();
-    });
-  });
+  }
 }

--- a/src/routes/watch.ts
+++ b/src/routes/watch.ts
@@ -14,10 +14,18 @@ export function registerWatchRoutes(
       // Validate the file exists before setting up the watcher
       try {
         await readMarkdown(source.directory, filename);
-      } catch {
-        return reply
-          .status(404)
-          .send({ error: `File "${filename}" not found` });
+      } catch (error: unknown) {
+        if (error instanceof Error) {
+          if ("code" in error && error.code === "ENOENT") {
+            return reply
+              .status(404)
+              .send({ error: `File "${filename}" not found` });
+          }
+          if (error.message.includes("Path traversal")) {
+            return reply.status(403).send({ error: "Forbidden" });
+          }
+        }
+        return reply.status(500).send({ error: "Internal server error" });
       }
 
       reply.raw.writeHead(200, {

--- a/src/server.ts
+++ b/src/server.ts
@@ -19,7 +19,6 @@ export function createApp(config: Config): FastifyInstance {
   const app = Fastify();
 
   const sourceNames = config.sources.map((s) => s.name);
-  const sourceSet = new Set(sourceNames);
 
   app.decorateRequest("nonce", "");
 
@@ -40,38 +39,38 @@ export function createApp(config: Config): FastifyInstance {
   registerFileRoutes(app, config.sources);
   registerWatchRoutes(app, config.sources);
 
-  // HTML page routes
+  // Root index
   app.get("/", async (request, reply) => {
     void reply.type("text/html");
     return renderListingPage("agent-md-server", request.nonce, sourceNames);
   });
 
-  app.get<{ Params: { source: string } }>("/:source/", async (request, reply) => {
-    const { source } = request.params;
-    if (!sourceSet.has(source)) {
-      void reply.code(404);
-      return "Not Found";
-    }
-    void reply.type("text/html");
-    return renderListingPage(source, request.nonce);
-  });
+  // Per-source HTML routes. A source name may contain "/" (e.g. "claude/plans"),
+  // so we register explicit routes per source rather than using a /:source param,
+  // which would only match a single path segment.
+  for (const source of config.sources) {
+    const prefix = `/${source.name}`;
 
-  // Clean URLs: /plans/foo renders the view, /api/plans/foo.md serves raw markdown
-  app.get<{ Params: { source: string; file: string } }>("/:source/:file", async (request, reply) => {
-    const { source, file } = request.params;
+    app.get(`${prefix}/`, async (request, reply) => {
+      void reply.type("text/html");
+      return renderListingPage(source.name, request.nonce);
+    });
 
-    if (!sourceSet.has(source)) {
-      void reply.code(404);
-      return "Not Found";
-    }
-    if (file.endsWith(".md")) {
-      void reply.redirect(`/${source}/${file.slice(0, -3)}`);
-      return;
-    }
+    app.get<{ Params: { file: string } }>(
+      `${prefix}/:file`,
+      async (request, reply) => {
+        const { file } = request.params;
 
-    void reply.type("text/html");
-    return renderShell(file, request.nonce);
-  });
+        if (file.endsWith(".md")) {
+          void reply.redirect(`${prefix}/${file.slice(0, -3)}`);
+          return;
+        }
+
+        void reply.type("text/html");
+        return renderShell(file, request.nonce, source.name);
+      },
+    );
+  }
 
   return app;
 }

--- a/src/templates/shell.ts
+++ b/src/templates/shell.ts
@@ -1,4 +1,8 @@
-export function renderShell(title: string, nonce: string): string {
+export function renderShell(
+  title: string,
+  nonce: string,
+  sourcePrefix: string,
+): string {
   return `<!DOCTYPE html>
 <html lang="en">
 <head>
@@ -72,7 +76,7 @@ export function renderShell(title: string, nonce: string): string {
 <body>
   <div class="status-banner" id="status"></div>
   <div class="container">
-    <a class="back-link" id="back-link" href="/">&larr; Back</a>
+    <a class="back-link" id="back-link" href="/${escapeHtml(sourcePrefix)}/">&larr; Back</a>
     <h1 class="page-title">${escapeHtml(title)}</h1>
     <div class="markdown-body" id="content">
       <p style="color:#8b949e;">Loading&hellip;</p>
@@ -112,15 +116,10 @@ export function renderShell(title: string, nonce: string): string {
     const statusEl = document.getElementById('status');
 
     // Derive API and SSE URLs: /plans/foo → /api/plans/foo.md
+    // (works for any source-prefix depth, e.g. /claude/plans/foo → /api/claude/plans/foo.md)
     const pagePath = window.location.pathname;
     const apiUrl = '/api' + pagePath + '.md';
     const sseUrl = '/events' + pagePath + '.md';
-
-    // Set back link to parent source listing
-    const parts = pagePath.split('/').filter(Boolean);
-    if (parts.length > 0) {
-      document.getElementById('back-link').href = '/' + parts[0] + '/';
-    }
 
     function showStatus(message) {
       statusEl.textContent = message;

--- a/src/templates/shell.ts
+++ b/src/templates/shell.ts
@@ -1,7 +1,7 @@
 export function renderShell(
   title: string,
   nonce: string,
-  sourcePrefix: string,
+  sourceName: string,
 ): string {
   return `<!DOCTYPE html>
 <html lang="en">
@@ -76,7 +76,7 @@ export function renderShell(
 <body>
   <div class="status-banner" id="status"></div>
   <div class="container">
-    <a class="back-link" id="back-link" href="/${escapeHtml(sourcePrefix)}/">&larr; Back</a>
+    <a class="back-link" href="/${escapeHtml(sourceName)}/">&larr; Back</a>
     <h1 class="page-title">${escapeHtml(title)}</h1>
     <div class="markdown-body" id="content">
       <p style="color:#8b949e;">Loading&hellip;</p>


### PR DESCRIPTION
## Summary

- Relax `VALID_SOURCE_NAME` to accept one-or-more `[a-z0-9-]` segments joined by `/` (rejects leading/trailing slashes, double slashes, empty segments, uppercase).
- Add `claude/plans` → `~/.claude/plans` as a default source, so Claude Code's built-in plan-mode files are served at `/claude/plans/<file>` on a fresh install.
- Register routes per configured source at boot time instead of using a single `/:source/...` param, which Fastify only matches against a single segment. Source names like `claude/plans` now become literal URL path prefixes.
- Inject the source name into the viewer shell template so the Back link is correct for multi-segment sources.
- Reject overlapping source names at config load (e.g. `plans` + `plans/foo`), which would otherwise produce silent Fastify route collisions.
- Warn when sources config is empty.
- Fix `watch.ts` error classification to mirror `file.ts` (403 on path traversal, 404 on missing, 500 on other).
- Drop unused `@fastify/static` dependency.

## Note on issue body

The issue suggested using `@fastify/static` with `prefix: "/claude/plans/"`. The package is listed in `package.json` but isn't actually used anywhere — the server uses Fastify parametric routes. The real fix was relaxing the regex + switching to per-source route registration. (We also dropped the unused dep while we were here.)

## Test plan

- [x] Build passes (`pnpm build`).
- [x] Regex unit check: accepts `plans`, `claude/plans`, `a/b/c`, `foo-bar`; rejects `/foo`, `foo/`, `foo//bar`, `foo bar`, empty, `Foo`, `foo/Bar`.
- [x] Overlap guard: `plans` + `plans/foo` exits with clear error naming both.
- [x] Empty sources: prints warning to stderr.
- [x] Fresh install (no config file) serves `/`, `/plans/`, `/claude/plans/`, `/temp/` (all 200); unknown prefixes 404.
- [x] File view, raw API, and SSE all work under `/claude/plans/<file>`.
- [x] SSE pushes `data: changed` on file mtime change under the nested source.
- [x] Watch route: 404 missing, 403 path traversal, 200 SSE on real file.
- [x] README updated: example config, defaults table, naming rule, URL scheme note.

Closes #12
Closes #14
Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)