### PR TITLE
refactor: sources as a list of {prefix, root, hidden} objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,11 +31,11 @@ The config file lives at `~/.config/agent-md-server/config.json`.
 
 ```json
 {
-  "sources": {
-    "plans": "~/plans",
-    "claude/plans": "~/.claude/plans",
-    "temp": "/tmp/agent-md-server"
-  },
+  "sources": [
+    {"prefix": "plans", "root": "~/plans"},
+    {"prefix": "claude/plans", "root": "~/.claude/plans", "hidden": true},
+    {"prefix": "temp", "root": "/tmp/agent-md-server"}
+  ],
   "port": 3333,
   "host": "127.0.0.1",
   "tailscale": false
@@ -47,20 +47,23 @@ Defaults are applied when the config file is missing or a field is omitted.
 
 ### Sources
 
-Sources are name-to-path mappings.
-Each source name becomes a URL prefix (`/plans/`, `/claude/plans/`, `/temp/`, etc.).
+Each source is an object with a URL `prefix` and a filesystem `root`, matching `@fastify/static` conventions.
 
-- Names are one or more `[a-z0-9-]` segments joined by `/`. Each segment becomes a URL path segment — e.g. `claude/plans` is served at `/claude/plans/`.
-- Paths support `~` expansion to the home directory.
-- Directories are created automatically if they do not exist.
+- `prefix` — one or more `[a-z0-9-]` segments joined by `/`. Each segment becomes a URL path segment — e.g. `claude/plans` is served at `/claude/plans/`.
+- `root` — filesystem directory. Supports `~` expansion to the home directory. Created automatically if it does not exist.
+- `hidden` — optional boolean (default `false`). When `true`, the source is served normally but omitted from MCP tool descriptions, `list_paths`, and the browser root index. Use for fallback directories you want available by absolute-path lookup without advertising them.
+
+Two sources cannot have overlapping prefixes (e.g. `plans` and `plans/foo` would collide) — the server exits at boot with a clear error if this happens.
 
 Default sources when no config file is present:
 
-| Name | Path |
-|------|------|
-| `plans` | `~/plans` |
-| `claude/plans` | `~/.claude/plans` |
-| `temp` | `/tmp/agent-md-server` |
+| Prefix | Root | Hidden |
+|--------|------|:-:|
+| `plans` | `~/plans` | |
+| `claude/plans` | `~/.claude/plans` | ✓ |
+| `temp` | `/tmp/agent-md-server` | |
+
+> **Note:** In v0.1.0 the `sources` field changed from a `{name: path}` map to a list of `{prefix, root, hidden?}` objects. The old shape is rejected at boot with an error pointing to the new shape.
 
 ## CLI flags
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -5,7 +5,7 @@ import node_util from "node:util";
 
 import type { Config, SourceConfig } from "./types.js";
 
-const VALID_SOURCE_NAME = /^[a-z0-9-]+(\/[a-z0-9-]+)*$/;
+const VALID_PREFIX = /^[a-z0-9-]+(\/[a-z0-9-]+)*$/;
 
 const CONFIG_PATH = node_path.join(
   node_os.homedir(),
@@ -14,18 +14,24 @@ const CONFIG_PATH = node_path.join(
   "config.json",
 );
 
-const DEFAULT_SOURCES: Record<string, string> = {
-  plans: "~/plans",
-  "claude/plans": "~/.claude/plans",
-  temp: "/tmp/agent-md-server",
-};
+const DEFAULT_SOURCES: SourceConfig[] = [
+  { prefix: "plans", root: "~/plans" },
+  { prefix: "claude/plans", root: "~/.claude/plans", hidden: true },
+  { prefix: "temp", root: "/tmp/agent-md-server" },
+];
 
 const DEFAULT_PORT = 3333;
 const DEFAULT_HOST = "127.0.0.1";
 const DEFAULT_TAILSCALE = false;
 
+interface RawSource {
+  prefix?: unknown;
+  root?: unknown;
+  hidden?: unknown;
+}
+
 interface RawConfig {
-  sources?: Record<string, string>;
+  sources?: unknown;
   port?: number;
   host?: string;
   tailscale?: boolean;
@@ -38,44 +44,80 @@ function resolveTilde(filePath: string) {
   return filePath;
 }
 
-function validateSourceName(name: string) {
-  if (!VALID_SOURCE_NAME.test(name)) {
+function validatePrefix(prefix: string) {
+  if (!VALID_PREFIX.test(prefix)) {
     throw new Error(
-      `Invalid source name "${name}": must be one or more [a-z0-9-] segments joined by "/" (e.g. "plans" or "claude/plans")`,
+      `Invalid source prefix "${prefix}": must be one or more [a-z0-9-] segments joined by "/" (e.g. "plans" or "claude/plans")`,
     );
   }
 }
 
-function validateSourceSet(names: string[]) {
-  // Reject overlapping source names — one cannot be a path-prefix of another.
+function validateSourceSet(prefixes: string[]) {
+  // Reject overlapping prefixes — one cannot be a path-prefix of another.
   // e.g. "plans" + "plans/foo" would produce Fastify route collisions between
   // "/plans/:file" (file under outer) and "/plans/foo/" (listing for inner).
-  for (let i = 0; i < names.length; i++) {
-    for (let j = i + 1; j < names.length; j++) {
-      const [a, b] = [names[i], names[j]];
+  for (let i = 0; i < prefixes.length; i++) {
+    for (let j = i + 1; j < prefixes.length; j++) {
+      const [a, b] = [prefixes[i], prefixes[j]];
       if (
         a === b ||
         a.startsWith(b + "/") ||
         b.startsWith(a + "/")
       ) {
         throw new Error(
-          `Overlapping source names "${a}" and "${b}": one cannot be a path-prefix of the other`,
+          `Overlapping source prefixes "${a}" and "${b}": one cannot be a path-prefix of the other`,
         );
       }
     }
   }
 }
 
-function transformSources(sources: Record<string, string>): SourceConfig[] {
-  const entries = Object.entries(sources);
-  for (const [name] of entries) {
-    validateSourceName(name);
+function parseSources(raw: unknown): SourceConfig[] {
+  if (raw === undefined) {
+    return DEFAULT_SOURCES.map((s) => ({ ...s, root: resolveTilde(s.root) }));
   }
-  validateSourceSet(entries.map(([name]) => name));
-  return entries.map(([name, directory]) => ({
-    name,
-    directory: resolveTilde(directory),
-  }));
+
+  if (!Array.isArray(raw)) {
+    throw new Error(
+      `Invalid "sources": expected an array of {prefix, root, hidden?} objects. ` +
+        `The map shape ({"plans": "~/plans"}) was removed in favor of a list. ` +
+        `Example: [{"prefix": "plans", "root": "~/plans"}, {"prefix": "claude/plans", "root": "~/.claude/plans", "hidden": true}]`,
+    );
+  }
+
+  const sources: SourceConfig[] = raw.map((entry: unknown, index) => {
+    if (entry === null || typeof entry !== "object" || Array.isArray(entry)) {
+      throw new Error(
+        `Invalid "sources[${index}]": expected an object with {prefix, root, hidden?}`,
+      );
+    }
+    const src = entry as RawSource;
+    if (typeof src.prefix !== "string") {
+      throw new Error(
+        `Invalid "sources[${index}].prefix": expected string, got ${typeof src.prefix}`,
+      );
+    }
+    if (typeof src.root !== "string") {
+      throw new Error(
+        `Invalid "sources[${index}].root": expected string, got ${typeof src.root}`,
+      );
+    }
+    if (src.hidden !== undefined && typeof src.hidden !== "boolean") {
+      throw new Error(
+        `Invalid "sources[${index}].hidden": expected boolean, got ${typeof src.hidden}`,
+      );
+    }
+    validatePrefix(src.prefix);
+    const result: SourceConfig = {
+      prefix: src.prefix,
+      root: resolveTilde(src.root),
+    };
+    if (src.hidden === true) result.hidden = true;
+    return result;
+  });
+
+  validateSourceSet(sources.map((s) => s.prefix));
+  return sources;
 }
 
 async function readConfigFile(): Promise<RawConfig | undefined> {
@@ -97,7 +139,7 @@ async function readConfigFile(): Promise<RawConfig | undefined> {
 async function ensureDirectories(sources: SourceConfig[]) {
   await Promise.all(
     sources.map((source) =>
-      node_fs.mkdir(source.directory, { recursive: true }),
+      node_fs.mkdir(source.root, { recursive: true }),
     ),
   );
 }
@@ -123,7 +165,7 @@ export async function loadConfig(): Promise<Config> {
   const raw = await readConfigFile();
   const args = parseArgs();
 
-  const sources = transformSources(raw?.sources ?? DEFAULT_SOURCES);
+  const sources = parseSources(raw?.sources);
   if (sources.length === 0) {
     console.warn(
       "No sources configured; only the root index will be served.",

--- a/src/main.ts
+++ b/src/main.ts
@@ -69,7 +69,8 @@ async function main() {
     `MCP endpoint: http://${config.host}:${config.port}/mcp`,
   );
   for (const source of config.sources) {
-    console.log(`  ${source.name} → ${source.directory}`);
+    const tag = source.hidden ? " (hidden)" : "";
+    console.log(`  ${source.prefix} → ${source.root}${tag}`);
   }
 
   if (config.tailscale) {

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -13,7 +13,8 @@ import type { Renderer } from "./renderer.js";
 /**
  * Reverse-map an absolute filesystem path to a configured source.
  * Returns the matching source and the relative path within it, or undefined
- * if the path doesn't fall within any source directory.
+ * if the path doesn't fall within any source directory. Hidden sources are
+ * included — `hidden` only controls discovery surfaces, not resolution.
  */
 function resolvePathToSource(
   sources: SourceConfig[],
@@ -21,7 +22,7 @@ function resolvePathToSource(
 ): { source: SourceConfig; relative: string } | undefined {
   const resolved = path.resolve(absolutePath);
   for (const source of sources) {
-    const sourceDir = path.resolve(source.directory);
+    const sourceDir = path.resolve(source.root);
     if (resolved.startsWith(sourceDir + path.sep)) {
       const relative = path.relative(sourceDir, resolved);
       if (relative.includes("..")) return undefined;
@@ -43,8 +44,13 @@ export function createMcpServer(config: Config, renderer: Renderer): Server {
     return (config.tailscaleUrl ?? baseUrl).replace(/\/+$/, "");
   }
 
+  // Visible sources are surfaced in tool descriptions and `list_paths`.
+  // Hidden sources are excluded from these discovery surfaces but remain
+  // resolvable via `get_url` when given an absolute path under them.
+  const visibleSources = config.sources.filter((s) => !s.hidden);
+
   function sourceListDescription(): string {
-    return config.sources.map((s) => s.directory).join(", ");
+    return visibleSources.map((s) => s.root).join(", ");
   }
 
   function pathNotInSourceError(): { content: { type: string; text: string }[]; isError: true } {
@@ -112,7 +118,7 @@ export function createMcpServer(config: Config, renderer: Renderer): Server {
 
         // Validate the file exists and isn't a symlink escape
         try {
-          await resolveSafePath(match.source.directory, match.relative);
+          await resolveSafePath(match.source.root, match.relative);
         } catch (e) {
           return {
             content: [{ type: "text", text: (e as Error).message }],
@@ -125,8 +131,8 @@ export function createMcpServer(config: Config, renderer: Renderer): Server {
           : match.relative;
 
         // Render and validate via Playwright
-        const safePath = path.resolve(match.source.directory, match.relative);
-        const result = await renderer.render(match.source.name, viewName, safePath);
+        const safePath = path.resolve(match.source.root, match.relative);
+        const result = await renderer.render(match.source.prefix, viewName, safePath);
 
         if (result.status === "error") {
           const errorList = result.errors
@@ -138,7 +144,7 @@ export function createMcpServer(config: Config, renderer: Renderer): Server {
           };
         }
 
-        const url = `${viewerUrl()}/${match.source.name}/${viewName}`;
+        const url = `${viewerUrl()}/${match.source.prefix}/${viewName}`;
         return {
           content: [{ type: "text", text: JSON.stringify({ status: "ok", url }) }],
         };
@@ -146,9 +152,9 @@ export function createMcpServer(config: Config, renderer: Renderer): Server {
 
       case "list_paths": {
         const sections: string[] = [];
-        for (const source of config.sources) {
-          const files = await listFiles(source.directory);
-          const dir = path.resolve(source.directory);
+        for (const source of visibleSources) {
+          const files = await listFiles(source.root);
+          const dir = path.resolve(source.root);
           const paths = files.map((f) => path.join(dir, f.name));
           sections.push(
             `${dir}/\n${paths.length === 0 ? "  (empty)" : paths.map((p) => `  ${p}`).join("\n")}`,

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -1,5 +1,9 @@
+// `page.evaluate` callbacks run in the Playwright browser context where
+// `document` is defined. Scope DOM types to this file so tsc is happy.
+/// <reference lib="dom" />
+
 import { stat } from "node:fs/promises";
-import { chromium, type Browser, type Page } from "playwright";
+import { chromium, type Browser } from "playwright";
 
 export interface RenderSuccess {
   status: "ok";

--- a/src/routes/file.ts
+++ b/src/routes/file.ts
@@ -8,11 +8,11 @@ export function registerFileRoutes(
   sources: SourceConfig[],
 ): void {
   for (const source of sources) {
-    app.get(`/api/${source.name}/:file`, async (request, reply) => {
+    app.get(`/api/${source.prefix}/:file`, async (request, reply) => {
       const { file: filename } = request.params as { file: string };
 
       try {
-        const content = await readMarkdown(source.directory, filename);
+        const content = await readMarkdown(source.root, filename);
         return reply
           .header("Content-Type", "text/markdown; charset=utf-8")
           .send(content);

--- a/src/routes/listing.ts
+++ b/src/routes/listing.ts
@@ -8,11 +8,11 @@ export function registerListingRoutes(
   sources: SourceConfig[],
 ): void {
   for (const source of sources) {
-    app.get(`/api/${source.name}/`, async (_request, reply) => {
-      const files = await listFiles(source.directory);
+    app.get(`/api/${source.prefix}/`, async (_request, reply) => {
+      const files = await listFiles(source.root);
       const mapped = files.map((entry) => ({
         ...entry,
-        path: `/${source.name}/${entry.name}`,
+        path: `/${source.prefix}/${entry.name}`,
       }));
 
       return reply.send(mapped);

--- a/src/routes/watch.ts
+++ b/src/routes/watch.ts
@@ -8,12 +8,12 @@ export function registerWatchRoutes(
   sources: SourceConfig[],
 ): void {
   for (const source of sources) {
-    app.get(`/events/${source.name}/:file`, async (request, reply) => {
+    app.get(`/events/${source.prefix}/:file`, async (request, reply) => {
       const { file: filename } = request.params as { file: string };
 
       // Validate the file exists before setting up the watcher
       try {
-        await readMarkdown(source.directory, filename);
+        await readMarkdown(source.root, filename);
       } catch (error: unknown) {
         if (error instanceof Error) {
           if ("code" in error && error.code === "ENOENT") {
@@ -35,7 +35,7 @@ export function registerWatchRoutes(
       });
       reply.hijack();
 
-      const cleanup = watchFile(source.directory, filename, () => {
+      const cleanup = watchFile(source.root, filename, () => {
         reply.raw.write("data: changed\n\n");
       });
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -18,7 +18,10 @@ declare module "fastify" {
 export function createApp(config: Config): FastifyInstance {
   const app = Fastify();
 
-  const sourceNames = config.sources.map((s) => s.name);
+  // Hidden sources are served but not listed on the root index.
+  const visiblePrefixes = config.sources
+    .filter((s) => !s.hidden)
+    .map((s) => s.prefix);
 
   app.decorateRequest("nonce", "");
 
@@ -34,7 +37,8 @@ export function createApp(config: Config): FastifyInstance {
     );
   });
 
-  // API and SSE routes
+  // API and SSE routes (hidden sources still get routes — `hidden` only
+  // controls discovery, not reachability)
   registerListingRoutes(app, config.sources);
   registerFileRoutes(app, config.sources);
   registerWatchRoutes(app, config.sources);
@@ -42,32 +46,32 @@ export function createApp(config: Config): FastifyInstance {
   // Root index
   app.get("/", async (request, reply) => {
     void reply.type("text/html");
-    return renderListingPage("agent-md-server", request.nonce, sourceNames);
+    return renderListingPage("agent-md-server", request.nonce, visiblePrefixes);
   });
 
-  // Per-source HTML routes. A source name may contain "/" (e.g. "claude/plans"),
+  // Per-source HTML routes. A source prefix may contain "/" (e.g. "claude/plans"),
   // so we register explicit routes per source rather than using a /:source param,
   // which would only match a single path segment.
   for (const source of config.sources) {
-    const prefix = `/${source.name}`;
+    const urlPrefix = `/${source.prefix}`;
 
-    app.get(`${prefix}/`, async (request, reply) => {
+    app.get(`${urlPrefix}/`, async (request, reply) => {
       void reply.type("text/html");
-      return renderListingPage(source.name, request.nonce);
+      return renderListingPage(source.prefix, request.nonce);
     });
 
     app.get<{ Params: { file: string } }>(
-      `${prefix}/:file`,
+      `${urlPrefix}/:file`,
       async (request, reply) => {
         const { file } = request.params;
 
         if (file.endsWith(".md")) {
-          void reply.redirect(`${prefix}/${file.slice(0, -3)}`);
+          void reply.redirect(`${urlPrefix}/${file.slice(0, -3)}`);
           return;
         }
 
         void reply.type("text/html");
-        return renderShell(file, request.nonce, source.name);
+        return renderShell(file, request.nonce, source.prefix);
       },
     );
   }

--- a/src/templates/shell.ts
+++ b/src/templates/shell.ts
@@ -1,7 +1,7 @@
 export function renderShell(
   title: string,
   nonce: string,
-  sourceName: string,
+  sourcePrefix: string,
 ): string {
   return `<!DOCTYPE html>
 <html lang="en">
@@ -76,7 +76,7 @@ export function renderShell(
 <body>
   <div class="status-banner" id="status"></div>
   <div class="container">
-    <a class="back-link" href="/${escapeHtml(sourceName)}/">&larr; Back</a>
+    <a class="back-link" href="/${escapeHtml(sourcePrefix)}/">&larr; Back</a>
     <h1 class="page-title">${escapeHtml(title)}</h1>
     <div class="markdown-body" id="content">
       <p style="color:#8b949e;">Loading&hellip;</p>

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,8 +6,17 @@ export interface FileEntry {
 }
 
 export interface SourceConfig {
-  name: string;
-  directory: string;
+  /** URL path prefix, e.g. "plans" or "claude/plans". */
+  prefix: string;
+  /** Filesystem directory. */
+  root: string;
+  /**
+   * When true, the source is served (routes register, `get_url` resolves) but
+   * is omitted from MCP tool descriptions, `list_paths`, and the browser root
+   * index. Use for fallback directories you want available by absolute-path
+   * lookup without advertising them.
+   */
+  hidden?: boolean;
 }
 
 export interface Config {


### PR DESCRIPTION
## Summary

**Breaking config change.** Move `sources` from a `{name: path}` map to a list of objects with `{prefix, root, hidden?}`. Attribute names follow `@fastify/static` vocabulary (the framework we use).

- New `hidden: true` flag — source is served normally (routes register, `get_url` resolves) but omitted from MCP tool descriptions, `list_paths`, and the browser root index. Use for fallback directories available by absolute-path lookup without advertising them.
- `claude/plans` now ships `hidden: true` by default, so `~/plans` is the primary plan destination and `~/.claude/plans` is a silent fallback.
- Old map shape rejected at boot with a clear error pointing to the new shape.
- Overlap validation (from #12) preserved with updated error messages (`prefix` vocabulary).
- Fixed a pre-existing `tsc --noEmit` failure in `src/renderer.ts` (DOM types scoped via triple-slash reference for the `page.evaluate` callback).

## Config shape

Before (rejected):
```json
{ "sources": { "plans": "~/plans" } }
```

After:
```json
{
  "sources": [
    {"prefix": "plans", "root": "~/plans"},
    {"prefix": "claude/plans", "root": "~/.claude/plans", "hidden": true},
    {"prefix": "temp", "root": "/tmp/agent-md-server"}
  ]
}
```

## Validation & test plan

- [x] `pnpm build` + `npx tsc --noEmit` both clean.
- [x] Fresh install (no config): serves `/`, `/plans/`, `/claude/plans/`, `/temp/` (200); MCP `tools/list` description for `get_url` shows only `~/plans` and `/tmp/agent-md-server`.
- [x] `list_paths` output omits the hidden `~/.claude/plans` directory.
- [x] `get_url` with an absolute path under a hidden source's root still resolves (`status: ok`, returns the viewer URL).
- [x] Overlap config (`plans` + `plans/foo`) rejected at boot with the updated prefix-vocabulary error.
- [x] Legacy map-shape config rejected with migration-pointing error.
- [x] Browser root index embeds only the non-hidden prefixes.

### MCP tool description validation (live server)

```
event: message
data: {"result":{"tools":[{"name":"get_url","description":"…Configured directories: /tmp/amd-mcp-a. Viewer: http://127.0.0.1:3410…"}]}}
```
Only `/tmp/amd-mcp-a` (visible) is in the description; `/tmp/amd-mcp-b` (hidden) is absent.

### `get_url` resolution for hidden source (live server)

```
event: message
data: {"result":{"content":[{"type":"text","text":"{\"status\":\"ok\",\"url\":\"http://127.0.0.1:3412/claude/plans/y\"}"}]}}
```
Hidden source still serves the viewer URL when given an absolute path.

## Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)