### PR TITLE
chore(infra): harden supply chain with pnpm 10.33 + minimumReleaseAge

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
   "author": "SemviaIO",
   "license": "MIT",
   "engines": {
-    "node": ">=22"
+    "node": ">=22",
+    "pnpm": "10.33.0"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.28.0",
@@ -36,5 +37,11 @@
     "tsx": "^4.19.0",
     "typescript": "^5.8.0"
   },
-  "packageManager": "pnpm@10.32.1"
+  "packageManager": "pnpm@10.33.0",
+  "pnpm": {
+    "minimumReleaseAge": 10080,
+    "minimumReleaseAgeExclude": [
+      "@semviaio/*"
+    ]
+  }
 }


### PR DESCRIPTION
## Summary

Hardens this repo against npm supply-chain attacks per [SemviaIO/SemviaIO#1047](https://github.com/SemviaIO/SemviaIO/issues/1047).

- `package.json`: `packageManager` + `engines.pnpm` bumped to `10.33.0`; added `pnpm.minimumReleaseAge: 10080` (7 days) and `minimumReleaseAgeExclude: ["@semviaio/*"]`
- No CI workflow edits — `pnpm/action-setup@v4` reads the version from `packageManager`

## Context

Same diff lands in every npm-installing repo in the org. The monorepo landed first in SemviaIO/SemviaIO#1048.

## Test plan

- [x] `pnpm install` — lockfile refreshed
- [x] `pnpm build` — passes (if defined)
- [x] `pnpm test` — passes (if defined)

Refs SemviaIO/SemviaIO#1047.

🤖 Generated with [Claude Code](https://claude.com/claude-code)