### PR TITLE
fix(launchd): exec real Node so kickstart -k frees port 3333

### DIFF
--- a/launchd/io.semvia.agent-md-server.plist
+++ b/launchd/io.semvia.agent-md-server.plist
@@ -4,6 +4,12 @@
   Template: copy to ~/Library/LaunchAgents/ and replace __HOME__ with your home directory.
   Or run: sed "s|__HOME__|$HOME|g" launchd/io.semvia.agent-md-server.plist > ~/Library/LaunchAgents/io.semvia.agent-md-server.plist
   Then: launchctl load ~/Library/LaunchAgents/io.semvia.agent-md-server.plist
+
+  ProgramArguments runs launchd/run.sh, which resolves the real Volta-pinned
+  Node binary and exec-replaces itself with it. This keeps launchd's tracked
+  PID identical to the process holding port 3333 — running ~/.volta/bin/node
+  directly forks the real Node as a child and strands an orphan on restart
+  (issue #24). Regenerate and reload this LaunchAgent once to pick up the fix.
 -->
 <plist version="1.0">
 <dict>
@@ -11,8 +17,7 @@
     <string>io.semvia.agent-md-server</string>
     <key>ProgramArguments</key>
     <array>
-        <string>__HOME__/.volta/bin/node</string>
-        <string>__HOME__/projects/SemviaIO/agent-md-server/dist/main.js</string>
+        <string>__HOME__/projects/SemviaIO/agent-md-server/launchd/run.sh</string>
     </array>
     <key>RunAtLoad</key>
     <true/>

--- a/launchd/run.sh
+++ b/launchd/run.sh
@@ -10,4 +10,12 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 NODE_BIN="$("$HOME/.volta/bin/volta" which node)"
 
+# `set -e` catches a non-zero `volta` exit; this guards the exit-0-bad-output
+# case so a clear message lands in /tmp/agent-md-server.log instead of an
+# opaque exec failure.
+if [[ ! -x "$NODE_BIN" ]]; then
+  echo "run.sh: Node resolution failed — 'volta which node' returned '$NODE_BIN', not an executable" >&2
+  exit 1
+fi
+
 exec "$NODE_BIN" "$SCRIPT_DIR/../dist/main.js"

--- a/launchd/run.sh
+++ b/launchd/run.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# launchd launcher for io.semvia.agent-md-server.
+#
+# Resolves the real Volta-pinned Node binary and exec-replaces this shell with
+# it, so the PID launchd tracks is the process that actually holds port 3333.
+# Launching via the ~/.volta/bin/node shim forks the real Node as a child,
+# which strands an orphan socket holder on `kickstart -k` — see issue #24.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+NODE_BIN="$("$HOME/.volta/bin/volta" which node)"
+
+exec "$NODE_BIN" "$SCRIPT_DIR/../dist/main.js"


### PR DESCRIPTION
Closes #24

## Summary

The launchd service ran the `~/.volta/bin/node` shim directly. The shim forks the real Volta-pinned Node as a *child* rather than `exec`-replacing itself, so launchd tracked the shim PID while a different PID held the port-3333 socket. `launchctl kickstart -k` killed the shim, stranded the orphan socket holder, and the fresh job crash-looped on `EADDRINUSE`.

- Add `launchd/run.sh` — resolves the real Node binary via `volta which node` and `exec`s it against `dist/main.js`. Because `exec` replaces the process image, launchd's tracked PID *becomes* the Node process holding the socket.
- Repoint the plist `ProgramArguments` at `run.sh` (single entry); update the header comment to document the indirection and the one-time reload migration.
- `volta which node` re-resolves on every launch, so the fix survives Node version bumps with no plist regeneration.

## Test plan

Manual on the macOS host (launchd/process-lifecycle fix, not unit-testable):

- [ ] `pnpm build`, then regenerate + reload the LaunchAgent from the updated template
- [ ] Confirm `launchctl print` PID matches `lsof -nP -iTCP:3333 -sTCP:LISTEN`
- [ ] `launchctl kickstart -k` — new single PID listens, old PID gone, no `EADDRINUSE` in `/tmp/agent-md-server.log`
- [ ] Repeat `kickstart -k` 2-3x to rule out a race

🤖 Generated with [Claude Code](https://claude.com/claude-code)