### PR TITLE
Host .html files alongside markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,9 @@ node dist/main.js
 
 Open <http://localhost:3333/> in your browser.
 
-The server watches configured source directories for `.md` files and renders them on demand.
-No build step is needed for content -- write a markdown file, open the URL, and it appears.
+The server serves `.md` files (rendered on demand) and `.html` files (served as-is) from
+the configured source directories.
+No build step is needed for content -- write a file, open the URL, and it appears.
 
 ## Configuration
 
@@ -125,17 +126,19 @@ If the `tailscale` command is not found, the server continues without it and pri
 /:source/sub/                  Listing for a sub-directory
 /:source/foo                   Rendered markdown (clean URL, no .md)
 /:source/sub/foo               Rendered markdown for a nested file
+/:source/page.html             Hosted HTML file (served as-is)
 /api/:source/                  JSON listing (files + directories)
 /api/:source/sub/              JSON listing for a sub-directory
 /api/:source/foo.md            Raw markdown content
 /api/:source/sub/foo.md        Raw markdown for a nested file
+/api/:source/page.html         Raw HTML content
 /events/:source/foo.md         SSE stream (emits on file change)
 /events/:source/sub/foo.md     SSE stream for a nested file
 ```
 
 `:source` may itself be a multi-segment prefix (e.g. `claude/plans`), in which case the URLs include each segment — `/claude/plans/foo`, `/api/claude/plans/foo.md`, etc.
 
-Sub-paths under a source are resolved lazily: each listing request reads exactly the directory it lists, with no upfront scan. Listings include both `.md` files and subdirectories (entries carry a `kind: "file" | "dir"` field). The following directory names are silently omitted from listings as a noise filter, so a source can safely point at a dev tree like `~/projects`:
+Sub-paths under a source are resolved lazily: each listing request reads exactly the directory it lists, with no upfront scan. Listings include `.md` files, `.html` files, and subdirectories (entries carry a `kind: "file" | "dir"` field). `.html` files are served as-is for the browser to render natively — the markdown viewer shell and SSE live-reload apply only to `.md` files. Because hosted HTML carries its own inline scripts and styles, the strict nonce-based Content-Security-Policy is dropped for raw HTML responses. The following directory names are silently omitted from listings as a noise filter, so a source can safely point at a dev tree like `~/projects`:
 
 ```
 node_modules, .git, dist, build, target, .next, .venv, __pycache__
@@ -143,7 +146,7 @@ node_modules, .git, dist, build, target, .next, .venv, __pycache__
 
 The denylist is a discovery filter only — direct URLs into those directories still resolve via the same `resolveSafePath` jail used by every other read.
 
-The `/api/` endpoints return JSON (listings) or raw markdown (files).
+The `/api/` endpoints return JSON (listings) or raw file content (`.md` as `text/markdown`, `.html` as `text/html`).
 The `/events/` endpoint opens a persistent SSE connection that sends a `changed` event whenever the file is modified on disk.
 The HTML views use these APIs internally -- the browser fetches markdown via `/api/`, renders it client-side, and subscribes to `/events/` for live updates.
 

--- a/src/fs.ts
+++ b/src/fs.ts
@@ -28,6 +28,17 @@ const IGNORED_DIRS = new Set([
 ]);
 
 /**
+ * File extensions the server hosts. `.md` is rendered through the markdown
+ * viewer; `.html` is served as-is. Anything else is omitted from listings
+ * and 404s on direct fetch.
+ */
+const SERVED_EXTENSIONS = [".md", ".html"];
+
+export function isServedFile(name: string): boolean {
+  return SERVED_EXTENSIONS.some((ext) => name.endsWith(ext));
+}
+
+/**
  * Resolve a filename within a source directory, rejecting any path that
  * escapes the jail. This is the critical security boundary -- every
  * filesystem read must go through this function.
@@ -72,11 +83,12 @@ export async function resolveSafePath(
 /**
  * List the immediate children of `sourceDir/subPath` as a flat array of
  * file and directory entries. One `readdir` per call -- no recursion.
- * Directories in `IGNORED_DIRS` are filtered out; non-`.md` files are
- * filtered out. The security boundary is `resolveSafePath`, which is
- * called on the resolved target before reading.
+ * Directories in `IGNORED_DIRS` are filtered out; files whose extension
+ * is not in `SERVED_EXTENSIONS` are filtered out. The security boundary
+ * is `resolveSafePath`, which is called on the resolved target before
+ * reading.
  *
- * Sort order: directories first (alphabetical), then `.md` files
+ * Sort order: directories first (alphabetical), then files
  * (most-recently-modified first -- preserves the flat-source default).
  */
 export async function listFiles(
@@ -101,7 +113,7 @@ export async function listFiles(
           path: path.posix.join(subPath, entry.name),
           modified: dirStat.mtime.toISOString(),
         });
-      } else if (entry.isFile() && entry.name.endsWith(".md")) {
+      } else if (entry.isFile() && isServedFile(entry.name)) {
         const filePath = path.join(targetDir, entry.name);
         const fileStat = await stat(filePath);
         fileEntries.push({
@@ -123,7 +135,7 @@ export async function listFiles(
   return [...dirEntries, ...fileEntries];
 }
 
-export async function readMarkdown(
+export async function readSourceFile(
   sourceDir: string,
   filename: string,
 ): Promise<string> {
@@ -140,7 +152,7 @@ export function watchFile(
   const joined = path.resolve(resolvedRoot, filename);
 
   // Synchronous prefix check -- the same logic as resolveSafePath but
-  // without the async realpath step. Callers MUST run readMarkdown (or
+  // without the async realpath step. Callers MUST run readSourceFile (or
   // an equivalent resolveSafePath call) before invoking watchFile, since
   // that is what catches symlink escapes; this function only validates
   // the normalised lexical path.

--- a/src/routes/api.ts
+++ b/src/routes/api.ts
@@ -1,6 +1,6 @@
 import type { FastifyInstance, FastifyReply } from "fastify";
 
-import { listFiles, readMarkdown } from "../fs.js";
+import { listFiles, readSourceFile } from "../fs.js";
 import type { SourceConfig } from "../types.js";
 import { sendFsError } from "./errors.js";
 
@@ -13,6 +13,7 @@ import { sendFsError } from "./errors.js";
  *   /api/${prefix}/*   — catch-all dispatching by suffix:
  *                          trailing slash → sub-directory listing
  *                          .md            → raw markdown
+ *                          .html          → raw HTML
  *                          otherwise      → 404
  *
  * Fastify rejects duplicate method+path registrations, so the bare
@@ -37,15 +38,26 @@ export function registerApiRoutes(
           return sendListing(reply, source, captured.replace(/\/+$/, ""));
         }
 
-        if (!captured.endsWith(".md")) {
-          return reply.status(404).send({ error: "Only .md files are served" });
+        const contentType = captured.endsWith(".md")
+          ? "text/markdown; charset=utf-8"
+          : captured.endsWith(".html")
+            ? "text/html; charset=utf-8"
+            : undefined;
+
+        if (contentType === undefined) {
+          return reply
+            .status(404)
+            .send({ error: "Only .md and .html files are served" });
         }
 
         try {
-          const content = await readMarkdown(source.root, captured);
-          return reply
-            .header("Content-Type", "text/markdown; charset=utf-8")
-            .send(content);
+          const content = await readSourceFile(source.root, captured);
+          // Hosted HTML carries its own inline scripts/styles that cannot
+          // be nonce-tagged, so the strict CSP is dropped for raw HTML.
+          if (captured.endsWith(".html")) {
+            void reply.removeHeader("Content-Security-Policy");
+          }
+          return reply.header("Content-Type", contentType).send(content);
         } catch (error: unknown) {
           return sendFsError(reply, error, captured);
         }

--- a/src/routes/errors.ts
+++ b/src/routes/errors.ts
@@ -1,7 +1,7 @@
 import type { FastifyReply } from "fastify";
 
 /**
- * Map a filesystem error from `resolveSafePath` / `readMarkdown` /
+ * Map a filesystem error from `resolveSafePath` / `readSourceFile` /
  * `listFiles` to the appropriate HTTP status. Centralises the mapping
  * so every route surfaces a consistent shape:
  *

--- a/src/routes/watch.ts
+++ b/src/routes/watch.ts
@@ -1,6 +1,6 @@
 import type { FastifyInstance } from "fastify";
 
-import { readMarkdown, watchFile } from "../fs.js";
+import { readSourceFile, watchFile } from "../fs.js";
 import type { SourceConfig } from "../types.js";
 import { sendFsError } from "./errors.js";
 
@@ -18,11 +18,11 @@ export function registerWatchRoutes(
           return reply.status(404).send({ error: "Only .md files are served" });
         }
 
-        // Validate the file via readMarkdown (full resolveSafePath check)
+        // Validate the file via readSourceFile (full resolveSafePath check)
         // BEFORE wiring the watcher. watchFile only does a synchronous
         // prefix check, so symlink-escape detection lives here.
         try {
-          await readMarkdown(source.root, filename);
+          await readSourceFile(source.root, filename);
         } catch (error: unknown) {
           return sendFsError(reply, error, filename);
         }

--- a/src/server.ts
+++ b/src/server.ts
@@ -5,9 +5,10 @@ import { stat } from "node:fs/promises";
 import Fastify, { type FastifyInstance } from "fastify";
 
 import type { Config } from "./types.js";
-import { resolveSafePath } from "./fs.js";
+import { resolveSafePath, readSourceFile } from "./fs.js";
 import { registerApiRoutes } from "./routes/api.js";
 import { registerWatchRoutes } from "./routes/watch.js";
+import { sendFsError } from "./routes/errors.js";
 import { renderShell } from "./templates/shell.js";
 import { renderListingPage } from "./templates/listing-page.js";
 
@@ -102,6 +103,21 @@ export function createApp(config: Config): FastifyInstance {
         if (captured.endsWith(".md")) {
           void reply.redirect(`${urlPrefix}/${captured.slice(0, -3)}`);
           return;
+        }
+
+        // `.html` URL → serve the file as-is for the browser to render
+        // natively (no markdown viewer shell). The strict nonce CSP is
+        // dropped here: hosted HTML carries its own inline scripts and
+        // styles that cannot be nonce-tagged, so the CSP would break it.
+        if (captured.endsWith(".html")) {
+          try {
+            const content = await readSourceFile(source.root, captured);
+            void reply.removeHeader("Content-Security-Policy");
+            void reply.type("text/html");
+            return content;
+          } catch (error: unknown) {
+            return sendFsError(reply, error, captured);
+          }
         }
 
         // If the captured path resolves to a directory on disk, redirect


### PR DESCRIPTION
## Summary

- Serve `.html` files as a first-class file type. `/<source>/page.html` serves the file as-is for the browser to render natively (no markdown viewer shell); `/api/<source>/page.html` returns the raw file as `text/html`.
- Directory listings (browser + `/api/` JSON) now include `.html` files alongside `.md`.
- The strict nonce-based CSP is dropped for raw HTML responses on both routes — hosted HTML carries its own inline scripts/styles that cannot be nonce-tagged, so the CSP would break it.
- `readMarkdown` renamed to `readSourceFile` since it now reads either file type. SSE live-reload stays markdown-only (raw HTML has no viewer shell to subscribe).

Closes #25

## Test plan

- [x] `pnpm typecheck` + `pnpm build` pass
- [x] `GET /<source>/page.html` → 200, `text/html`, no CSP header, raw file body
- [x] `GET /api/<source>/page.html` → 200, `text/html`, no CSP header
- [x] `GET /api/<source>/file.md` → still `text/markdown` with CSP intact
- [x] JSON + browser listings include both `.md` and `.html` entries
- [x] Missing `.html` file → 404
- [x] Existing markdown viewer route still renders (200)

🤖 Generated with [Claude Code](https://claude.com/claude-code)