### PR TITLE
feat(viewer): link to raw markdown in the top bar

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -145,6 +145,7 @@ export function createApp(config: Config): FastifyInstance {
           titleName,
           request.nonce,
           parentUrlOf(urlPrefix, captured),
+          `/api${urlPrefix}/${captured}.md`,
         );
       },
     );

--- a/src/templates/shell.ts
+++ b/src/templates/shell.ts
@@ -2,6 +2,7 @@ export function renderShell(
   title: string,
   nonce: string,
   parentUrl: string,
+  rawUrl: string,
 ): string {
   return `<!DOCTYPE html>
 <html lang="en">
@@ -35,14 +36,18 @@ export function renderShell(
       padding: 2rem 1.5rem;
     }
 
-    .back-link {
-      display: inline-block;
-      color: #58a6ff;
-      text-decoration: none;
+    .top-bar {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
       margin-bottom: 1rem;
       font-size: 0.875rem;
     }
-    .back-link:hover { text-decoration: underline; }
+    .top-bar a {
+      color: #58a6ff;
+      text-decoration: none;
+    }
+    .top-bar a:hover { text-decoration: underline; }
 
     .page-title {
       font-size: 1.75rem;
@@ -76,7 +81,10 @@ export function renderShell(
 <body>
   <div class="status-banner" id="status"></div>
   <div class="container">
-    <a class="back-link" href="${escapeHtml(parentUrl)}">&larr; Back</a>
+    <div class="top-bar">
+      <a href="${escapeHtml(parentUrl)}">&larr; Back</a>
+      <a href="${escapeHtml(rawUrl)}">View raw</a>
+    </div>
     <h1 class="page-title">${escapeHtml(title)}</h1>
     <div class="markdown-body" id="content">
       <p style="color:#8b949e;">Loading&hellip;</p>


### PR DESCRIPTION
## Summary

- Adds a **View raw** link to the viewer's top bar, pointing at the corresponding `/api/<prefix>/<path>.md` URL so users can grab the markdown source without having to know the API convention.
- Restructures the top of the page from a standalone back link to a flex `.top-bar` row holding back-left, raw-right.

Closes #28

## Test plan

- [ ] Start the server (`pnpm dev`) and open a markdown page; confirm `← Back` and `View raw` both render in the top bar.
- [ ] Click `View raw` and verify it serves the unrendered markdown from the `/api/...` path.
- [ ] Verify a nested file (e.g. `/plans/sub/foo`) produces a `View raw` URL of `/api/plans/sub/foo.md`.
- [ ] Confirm the back link still navigates one directory up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)