### PR TITLE
fix(launchd): probe volta in homebrew locations too

### DIFF
--- a/launchd/run.sh
+++ b/launchd/run.sh
@@ -8,7 +8,24 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-NODE_BIN="$("$HOME/.volta/bin/volta" which node)"
+
+# Locate the `volta` driver. The canonical installer drops it in
+# ~/.volta/bin/; Homebrew installs it under /opt/homebrew/bin (Apple Silicon)
+# or /usr/local/bin (Intel). launchd's default PATH excludes both Homebrew
+# prefixes, so probe known locations explicitly instead of relying on PATH.
+VOLTA_BIN=""
+for candidate in "$HOME/.volta/bin/volta" /opt/homebrew/bin/volta /usr/local/bin/volta; do
+  if [[ -x "$candidate" ]]; then
+    VOLTA_BIN="$candidate"
+    break
+  fi
+done
+if [[ -z "$VOLTA_BIN" ]]; then
+  echo "run.sh: volta not found in ~/.volta/bin, /opt/homebrew/bin, or /usr/local/bin" >&2
+  exit 1
+fi
+
+NODE_BIN="$("$VOLTA_BIN" which node)"
 
 # `set -e` catches a non-zero `volta` exit; this guards the exit-0-bad-output
 # case so a clear message lands in /tmp/agent-md-server.log instead of an


### PR DESCRIPTION
## Summary
- `launchd/run.sh` hardcoded `~/.volta/bin/volta`; that path only exists on canonical-installer Volta. On a Homebrew-Volta machine the driver is at `/opt/homebrew/bin/volta` (Intel: `/usr/local/bin/volta`), and `~/.volta/bin/` only holds toolchain shims — so launchd exited 127 in a retry loop and nothing bound port 3333.
- Probe known locations explicitly. launchd's default PATH (`/usr/bin:/bin:/usr/sbin:/sbin`) excludes both Homebrew prefixes, so PATH-based discovery isn't viable.
- Shim-avoidance from #24 preserved: we still go through `volta which node` and `exec` the real Node binary.

Closes #30

## Test plan
- [x] `bash -n launchd/run.sh` clean
- [x] `pnpm build` clean
- [x] On a Homebrew-Volta machine (where `~/.volta/bin/volta` is absent), launchd respawns the daemon successfully and `ps` shows the real Node binary (`~/.volta/tools/image/node/22.22.3/bin/node`), not the `~/.volta/bin/node` shim — preserving #24's port-3333 cleanup semantics
- [x] `lsof -i :3333 -sTCP:LISTEN` shows the daemon bound
- [x] `curl -X POST -H 'Accept: application/json, text/event-stream' http://127.0.0.1:3333/mcp` with an `initialize` payload returns `HTTP 200` and a well-formed MCP `serverInfo`/`capabilities` response
- [ ] Confirm on canonical-installer Volta machine — first candidate in the probe is unchanged from prior behavior, so this should be a no-op there

🤖 Generated with [Claude Code](https://claude.com/claude-code)