### PR TITLE
fix(deps): auto-install Chromium via postinstall

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "start:tailscale": "node dist/main.js --tailscale",
     "typecheck": "tsc --noEmit",
     "preflight": "pnpm typecheck && pnpm build",
-    "stress": "tsx scripts/stress-renderer.ts"
+    "stress": "tsx scripts/stress-renderer.ts",
+    "postinstall": "playwright install chromium"
   },
   "keywords": [
     "mermaid",


### PR DESCRIPTION
## Summary
- `src/renderer.ts:51` calls `chromium.launch()` unconditionally — Chromium is part of the runtime contract for this server, not optional.
- `playwright` as an npm dep only ships JS bindings; the ~170MB browser binary needs `playwright install chromium`, which nothing in this repo currently runs.
- Add a `postinstall` script so `pnpm install` leaves the package ready to serve.

Closes #32

## Test plan
- [x] Clean `~/Library/Caches/ms-playwright/`, wipe `node_modules`, `pnpm install` → postinstall fires, `chromium-1217` + `chromium_headless_shell-1217` land in the cache
- [x] `pnpm build && pnpm start` (via launchd kickstart) come up clean, port 3333 bound
- [x] MCP `tools/call` of `get_url` against a markdown file containing a real \`\`\`mermaid block returns `{"status":"ok","url":"…"}` — Chromium launched, mermaid validated end-to-end
- [ ] Confirm CI doesn't double-download on cache hit (Playwright's installer no-ops when the right version is present, so this should be cheap on subsequent runs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)