### PR TITLE
fix(tailscale): (re)run `tailscale serve` on startup so the tailnet URL stays live

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,11 +112,22 @@ If any block has syntax errors, the response includes per-block errors so the ag
 
 ## Tailscale
 
-The `--tailscale` flag runs `tailscale serve --bg` to expose the server on your tailnet over HTTPS.
+With `--tailscale` (or `"tailscale": true` in the config file), on startup the server
+runs `tailscale serve --bg --https=443 http://127.0.0.1:<port>` to expose itself on your
+tailnet over HTTPS, and advertises the resulting `https://<host>/` URL via the MCP tools.
 This lets you view rendered documents from any device on your Tailscale network.
 
-The serve rule is cleaned up automatically when the server exits (via SIGINT or SIGTERM).
-If the `tailscale` command is not found, the server continues without it and prints a warning.
+The serve rule is (re)established on every startup. `tailscale serve` persists its rule in
+tailscaled, but reboots, Tailscale app updates, and `tailscale serve reset` can wipe it —
+re-running on startup keeps the exposure self-healing, so the advertised URL never points
+at a dead listener. The rule is intentionally left in place on exit so the long-running
+(launchd) deployment stays reachable across restarts.
+
+The `tailscale` CLI is located by probing known install paths (Homebrew, `/usr/local/bin`,
+the Tailscale.app bundle), since launchd's PATH does not include them. If it cannot be found
+or the command fails (for example, no GUI/XPC session is available), the server continues
+without it and prints a warning; the advertised URL then works only if a serve rule was
+configured out of band.
 
 ## URL scheme
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,8 @@
+import { execFile } from "node:child_process";
 import dns from "node:dns";
+import { existsSync } from "node:fs";
 import os from "node:os";
+import { promisify } from "node:util";
 
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
 
@@ -7,6 +10,19 @@ import { loadConfig } from "./config.js";
 import { createMcpServer } from "./mcp.js";
 import { Renderer } from "./renderer.js";
 import { createApp } from "./server.js";
+
+const execFileAsync = promisify(execFile);
+
+/**
+ * launchd's PATH is bare (/usr/bin:/bin:/usr/sbin:/sbin), so the `tailscale`
+ * CLI is not discoverable by name. Probe known install locations, mirroring
+ * how run.sh probes for volta.
+ */
+const TAILSCALE_BIN_CANDIDATES = [
+  "/opt/homebrew/bin/tailscale",
+  "/usr/local/bin/tailscale",
+  "/Applications/Tailscale.app/Contents/MacOS/Tailscale",
+];
 
 async function main() {
   const config = await loadConfig();
@@ -74,7 +90,7 @@ async function main() {
   }
 
   if (config.tailscale) {
-    config.tailscaleUrl = await setupTailscale();
+    config.tailscaleUrl = await setupTailscale(config.port);
     if (config.tailscaleUrl) {
       console.log(`Tailscale: ${config.tailscaleUrl}`);
     }
@@ -86,7 +102,7 @@ async function main() {
   console.log("Playwright renderer ready");
 }
 
-async function setupTailscale(): Promise<string | undefined> {
+async function setupTailscale(port: number): Promise<string | undefined> {
   try {
     // Find the Tailscale IP from network interfaces (CGNAT range 100.64.0.0/10)
     const tailscaleIp = findTailscaleIp();
@@ -95,19 +111,50 @@ async function setupTailscale(): Promise<string | undefined> {
       return undefined;
     }
 
-    // Reverse DNS lookup via Tailscale's MagicDNS to get the hostname.
-    // This avoids the `tailscale` CLI which requires GUI/XPC and fails under launchd.
+    // Reverse DNS lookup via Tailscale's MagicDNS to get the hostname. This
+    // derives the URL without `tailscale status`, which can need GUI/XPC under
+    // launchd.
     const resolver = new dns.promises.Resolver();
     resolver.setServers(["100.100.100.100"]);
     const hostnames = await resolver.reverse(tailscaleIp);
     const dnsName = hostnames[0]?.replace(/\.$/, "");
-    if (dnsName) {
-      return `https://${dnsName}/`;
+    if (!dnsName) {
+      return undefined;
     }
+
+    // (Re)establish the tailnet HTTPS proxy on every startup. `tailscale serve`
+    // persists its rule in tailscaled, but reboots / app updates / `serve reset`
+    // can wipe it -- re-running here keeps the exposure self-healing so the
+    // advertised URL never points at a dead listener.
+    await ensureServeProxy(port);
+
+    return `https://${dnsName}/`;
   } catch (error: unknown) {
     console.warn("Warning: Tailscale setup failed:", String(error));
   }
   return undefined;
+}
+
+/**
+ * Runs `tailscale serve --bg` to proxy the tailnet HTTPS endpoint (:443) to the
+ * local server. Best-effort: if the CLI is missing or fails (e.g. no GUI/XPC
+ * session under launchd), the server still serves locally and advertises the
+ * URL, which keeps working as long as a serve rule was configured out of band.
+ */
+async function ensureServeProxy(port: number): Promise<void> {
+  const bin = TAILSCALE_BIN_CANDIDATES.find((candidate) => existsSync(candidate));
+  if (!bin) {
+    console.warn(
+      "Warning: tailscale CLI not found; skipping `tailscale serve`. The advertised URL only works if a serve rule is configured manually.",
+    );
+    return;
+  }
+  try {
+    await execFileAsync(bin, ["serve", "--bg", "--https=443", `http://127.0.0.1:${port}`]);
+    console.log(`Tailscale serve: tailnet :443 → http://127.0.0.1:${port}`);
+  } catch (error: unknown) {
+    console.warn("Warning: `tailscale serve` failed:", String(error));
+  }
 }
 
 function findTailscaleIp(): string | undefined {


### PR DESCRIPTION
Closes #34

## Problem

The MCP advertises `https://<host>/...` but from other tailnet devices it failed with **"refused to connect"** — `tailscale serve status` was empty. The local server (`:3333`) was healthy the whole time; only the tailnet proxy was gone.

`setupTailscale()` had regressed to deriving the URL only — it no longer ran `tailscale serve`. The proxy was a one-time manual `tailscale serve --bg` whose rule persisted in tailscaled until a reboot / Tailscale app update / `serve reset` wiped it. After that the MCP kept handing out a URL pointing at a dead `:443` listener, silently.

This contradicted the README, which still documented that `--tailscale` runs `tailscale serve --bg`.

## Fix

- `setupTailscale()` now (re)runs `tailscale serve --bg --https=443 http://127.0.0.1:<port>` on every startup, so the exposure self-heals regardless of what wiped it.
- The `tailscale` binary is located by probing known install paths (Homebrew, `/usr/local/bin`, the Tailscale.app bundle), because launchd's PATH is bare (`/usr/bin:/bin:/usr/sbin:/sbin`) — same pattern `run.sh` uses for volta.
- Best-effort with graceful degradation: a missing CLI or a failed command (e.g. no GUI/XPC session) logs a warning and falls back to URL-only — no regression vs. the prior behavior.
- README updated to match: the rule is re-established on startup and intentionally persists across restarts for the launchd daemon (not torn down on exit).

## Testing

- `pnpm preflight` (typecheck + build) green.
- Exercised the exact code path against the live instance: binary resolves to `/opt/homebrew/bin/tailscale`, the serve command succeeds, and `tailscale serve status` shows `/ proxy http://127.0.0.1:3333`. End-to-end fetch through `:443` returns HTTP 200 and renders.

## Deploy note

The live service runs from a separate `~/config/...` checkout. After merge, pull + rebuild + restart the LaunchAgent there to pick this up. The LaunchAgent runs in `gui/501`, so the Tailscale CLI has the aqua session it needs; watch `/tmp/agent-md-server.log` on first restart to confirm the `Tailscale serve:` line appears (vs. a warning).